### PR TITLE
Add userland field

### DIFF
--- a/_ext/cps.py
+++ b/_ext/cps.py
@@ -47,7 +47,7 @@ class InternalizeLinks(Transform):
                 ref.replace_self(xref)
 
 #==============================================================================
-def add_role(app, name, styles=None, parent=roles.generic_custom_role):
+def add_role(app, name, styles=None, parent=roles.generic_custom_role, override=False):
     options = {}
     if styles is None:
         styles=name
@@ -56,19 +56,16 @@ def add_role(app, name, styles=None, parent=roles.generic_custom_role):
 
     options['class'] = directives.class_option(styles)
     role = roles.CustomRole(name, parent, options)
-    app.add_role(name, role)
+    app.add_role(name, role, override=override)
 
 #==============================================================================
-def add_code_role(app, name, styles=None, parent=roles.code_role):
-    add_role(app, name, styles, parent)
+def add_code_role(app, name, styles=None, parent=roles.code_role, override=False):
+    add_role(app, name, styles, parent, override=override)
 
 #==============================================================================
 def setup(app):
     # Add custom transform to resolve cross-file references
     app.add_transform(InternalizeLinks)
-
-    # Remove built-in 'keyword' role so we can override it
-    del app.domains['std'].roles['keyword']
 
     # Add site-specific custom roles (these just apply styling)
     add_role(app, 'hidden')
@@ -79,7 +76,7 @@ def setup(app):
     add_code_role(app, 'feature')
     add_code_role(app, 'feature.opt', styles=['feature', 'optional'])
     add_code_role(app, 'feature.var', styles=['feature', 'var'])
-    add_code_role(app, 'keyword')
+    add_code_role(app, 'keyword', override=True)
     add_code_role(app, 'type')
     add_code_role(app, 'string')
     add_code_role(app, 'path')

--- a/schema.rst
+++ b/schema.rst
@@ -273,6 +273,15 @@ Specifies the name of the operating system kernel required by the package's comp
 
 Specifies the minimum operating system kernel version required by the package's components.
 
+:attribute:`Userland`
+---------------------------
+
+:Type: |string|
+:Applies To: |platform|
+:Required: No
+
+Specifies the userland on top of the kernel. This is useful for differentiating different Operating Systems using the same kernel, such as Android/Linux vs GNU/Linux, or macOS/Darwin vs ios/Darwin. Some examples include :string:`"gnu"`, :string:`"ios"`, and :string:`"android"`. If this is not specified an conformant implementation should consider this to be the most common userland for the kernel, such as :string:`"gnu"` for Linux and :string:`"macOS"` for Darwin.
+
 :attribute:`Link-Features`
 --------------------------
 

--- a/schema.rst
+++ b/schema.rst
@@ -43,7 +43,7 @@ Attribute names are case insensitive, although it is recommended that ``.cps`` f
 :Applies To: |platform|
 :Required: No
 
-Specifies that the package's CABI components require the specified C standard/runtime library. Typical (case-insensitive) values include :string:`"bsd"` (libc), :string:`"gnu"` (glibc), :string:`"mingw"` and :string:`"microsoft"`.
+Specifies that the package's CABI components require the specified C standard/runtime library. Typical (case-insensitive) values include :string:`"bsd"` (libc), :string:`"android"` (), :string:`"gnu"` (glibc), :string:`"mingw"` and :string:`"microsoft"`.
 
 :attribute:`C-Runtime-Version`
 ------------------------------

--- a/schema.rst
+++ b/schema.rst
@@ -43,7 +43,7 @@ Attribute names are case insensitive, although it is recommended that ``.cps`` f
 :Applies To: |platform|
 :Required: No
 
-Specifies that the package's CABI components require the specified C standard/runtime library. Typical (case-insensitive) values include :string:`"bsd"` (libc), :string:`"android"` (), :string:`"gnu"` (glibc), :string:`"mingw"` and :string:`"microsoft"`.
+Specifies that the package's CABI components require the specified C standard/runtime library. Typical (case-insensitive) values include :string:`"bsd"` (libc), :string:`"android"` (), :string:`"gnu"` (glibc), :string:`"mingw"`, :string:`"musl"`, and :string:`"microsoft"`.
 
 :attribute:`C-Runtime-Version`
 ------------------------------


### PR DESCRIPTION
In addition to the kernel and the kernel-version required, it's often useful (especially when cross compiling) to know what userland we're targeting. This is required to differentiate, for example, GNU/Linux from Android/Linux or macOS/Darwin from iOS/Darwin.

I believe with this, the kernel field, and the *-runtime-library fields we can fully represent this information.

Fixes #1 