### PR TITLE
Adjust how searching works

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -19,7 +19,7 @@ master_doc = 'index'
 project = u'Common Package Specification'
 copyright = u'2023, Matthew Woehlke'
 
-release = '.'.join(map(str, [0, 8, 2]))
+release = '.'.join(map(str, [0, 9, 0]))
 version = re.match('\\d+\.\\d+', release).group(0)
 
 language = 'en'

--- a/configurations.rst
+++ b/configurations.rst
@@ -74,11 +74,24 @@ an optional package with debug libraries,
 and another optional package with optional components).
 
 When a tool locates a CPS file, :var:`name`\ :path:`.cps`,
-the tool shall look in the same directory for any files named
-:var:`name`\ :path:`:`\ :glob:`*`\ :path:`.cps`,
-:var:`name`\ :path:`@`\ :glob:`*`\ :path:`.cps`, and
-:var:`name`\ :path:`:`\ :glob:`*`\ :path:`@`\ :glob:`*`\ :path:`.cps`
-(the asterisk (``*``) represents file globbing).
+the tool shall look in the same directory for any files
+which match any of the patterns
+(the asterisk (``*``) represents file globbing):
+
+  - :var:`name`\ :path:`:`\ :glob:`*`\ :path:`.cps`
+
+  - :var:`name`\ :path:`-`\ :glob:`*`\ :path:`.cps`
+
+  - :var:`name`\ :path:`@`\ :glob:`*`\ :path:`.cps`
+
+  - :var:`name`\ :path:`:`\ :glob:`*`\ :path:`@`\ :glob:`*`\ :path:`.cps`
+
+  - :var:`name`\ :path:`-`\ :glob:`*`\ :path:`@`\ :glob:`*`\ :path:`.cps`
+
+Patterns containing colon (``:``) shall be skipped
+on platforms for which that character
+is not permitted in file names (e.g. Windows).
+
 If any such package specifications are found,
 they shall be loaded at the same time,
 and their contents appended to the information loaded from the base CPS.
@@ -92,12 +105,14 @@ is a configuration-specific CPS.
 The structure of a configuration-specific CPS
 is the same as a common CPS, with three exceptions:
 
-- The per-configuration specification
-  must contain the `Configuration`_ attribute.
+- The only defined :object:`package` keys are
+  `Name`_, `Configuration`_, and `Components <Components\ (Package)>`_.
+  The first two are required.
+  Use of other attributes specified in the schema is ill-formed.
 
-- The per-configuration specification
-  may not specify any :object:`component` attributes
-  (e.g. :attribute:`Type`).
+- The per-configuration specification may not specify
+  any :object:`component` attributes (e.g. :attribute:`Type`).
+  Only :object:`configuration` attributes are allowed.
 
 - An attribute on a :object:`component`
   is considered to belong instead

--- a/searching.rst
+++ b/searching.rst
@@ -1,65 +1,77 @@
 Package Searching
 =================
 
-Tools shall locate a package by searching for a file
-:var:`name`\ :path:`.cps` or
-:var:`name`\ :path:`-`\ :glob:`*`\ :path:`.cps`
-(where the asterisk (``*``) is one or more characters
-excluding colon (``:``) and at-sign (``@``),
-allowing ``.cps`` files to supply a version number as part of their name
-so that multiple versions may be co-installed)
+Tools shall locate a package
+by searching for a file
+:var:`name`\ :path:`.cps`
 in the following paths:
 
-- :var:`prefix`\ :path:`/cps/` :applies-to:`(Windows)`
+- :var:`prefix`\ :path:`/cps/`
+  :applies-to:`(Windows)`
 
-- :var:`prefix`\ :path:`/`\ :var:`name`\ :path:`.framework/Resources/CPS/`
-  :applies-to:`(MacOS)`
+- :var:`prefix`\ :path:`/cps/`\ :var:`name-like`\ :path:`/`
+  :applies-to:`(Windows)`
 
 - :var:`prefix`\ :path:`/`\ :var:`name`\ :path:`.framework/Versions/`\
   :glob:`*`\ :path:`/Resources/CPS/`
-  :applies-to:`(MacOS)`
+  :applies-to:`(macOS)`
+
+- :var:`prefix`\ :path:`/`\ :var:`name`\ :path:`.framework/Resources/CPS/`
+  :applies-to:`(macOS)`
 
 - :var:`prefix`\ :path:`/`\ :var:`name`\
   :path:`.app/Contents/Resources/CPS/`
-  :applies-to:`(MacOS)`
+  :applies-to:`(macOS)`
 
 - :var:`prefix`\ :path:`/`\ :var:`libdir`\
-  :path:`/cps/`\ :var:`name`\ :path:`/`\ :glob:`*`\ :path:`/`
-
-- :var:`prefix`\ :path:`/`\
-  :var:`libdir`\ :path:`/cps/`\ :var:`name`\ :path:`/`
+  :path:`/cps/`\ :var:`name-like`\ :path:`/`
 
 - :var:`prefix`\ :path:`/`\
   :var:`libdir`\ :path:`/cps/`
 
 - :var:`prefix`\ :path:`/share/cps/`\
-  :var:`name`\ :path:`/`\ :glob:`*`\ :path:`/`
-
-- :var:`prefix`\ :path:`/share/cps/`\
-  :var:`name`\ :path:`/`
+  :var:`name-like`\ :path:`/`
 
 - :var:`prefix`\ :path:`/share/cps/`
 
-The placeholder :var:`name` shall represent
-the name of the package to be located,
-and shall include both the proper case name,
-and the name converted to lower case.
-The placeholder :var:`libdir` shall be
-the platform defined directories, sans root prefix,
-in which matching architecture
-and/or architecture-neutral libraries reside
-(e.g. :path:`lib`, :path:`lib32`, :path:`lib64`,
-:path:`lib/i386-linux-gnu`...).
-The placeholder :var:`prefix` shall represent
-one of the set of default install prefixes to be searched,
-which shall include, at minimum and in order,
-the set of paths (separated by :path:`;` on Windows, :path:`:` otherwise)
-in the environment variable :env:`CPS_PATH`,
-:path:`/usr/local`, and :path:`/usr`.
-In addition,
-for all such package-neutral prefixes :var:`prefix-root`,
-the package-specific prefix :var:`prefix-root`\ :path:`/`\ :var:`name`
-shall also be considered.
+The various placeholders are as follows:
+
+:var:`name`:
+  The name of the package to be located,
+  including both the proper case name,
+  and the name converted to lower case.
+
+:var:`name-like`:
+  Any of
+  :var:`name`\ :path:`/`\ :glob:`*`,
+  :var:`name`\ :path:`-`\ :glob:`*`, or
+  :var:`name`,
+  where :var:`name`: is as previously defined,
+  and the asterisk (``*``) is one or more
+  valid filename characters, excluding the path separator.
+  This is intended to allow multiple versions of a package
+  to be installed into the same :var:`prefix`.
+
+:var:`libdir`:
+  The platform defined directories, sans root prefix,
+  in which matching architecture
+  and/or architecture-neutral libraries reside
+  (e.g. :path:`lib`, :path:`lib32`, :path:`lib64`,
+  :path:`lib/x86_64-linux-gnu`...).
+
+:var:`prefix`:
+  One of the set of default install prefixes to be searched,
+  which shall include, at minimum and in order,
+  the set of paths (separated by :path:`;` on Windows, :path:`:` otherwise)
+  in the environment variable :env:`CPS_PATH`,
+  :path:`/usr/local`, and :path:`/usr`.
+
+  In addition,
+  for all such package-neutral prefixes :var:`prefix-root`,
+  the package-specific prefixes
+  :var:`prefix-root`\ :path:`/`\ :var:`name-like`
+  shall also be considered.
+
 The complete list of search paths, above,
 shall be considered in the order specified above,
 for each prefix, before the next prefix is searched.
@@ -109,7 +121,7 @@ This can be accomplished in three ways:
   - The path is initially taken to be the directory portion
     (i.e. without file name) of the absolute path to the ``.cps`` file.
 
-  - :applies-to:`(MacOS)`
+  - :applies-to:`(macOS)`
     If the tail-portion matches
     :path:`/Resources/` or :path:`/Resources/CPS/`,
     then:


### PR DESCRIPTION
Allow `-` as a separator in e.g. `<name>-<component>.cps`. This is required as `:` is not available on e.g. Windows. (We might be able to use some other character, but even `-` introduces a disjoint convention, as `:` is otherwise used as the component separator. However, there is at least precedent for using `-` as a separator.)

In order to avoid serious confusion in light of this change, remove support for `<name>-*.cps`. This also means that the CPS file name relative to the package name is much more deterministic. In order to continue to support multiple versions of a package, add additional search paths and generally clean up the set of search paths to be more consistent.

Arguably, this should entail a major version bump, although as we are pre-1.0, we are probably going to make explicit at some point that, prior to 1.0, breaking changes may occur at minor version bumps. (In any case, things are likely to remain "rough" while we are in the early stages of roll-out.)

## COMMENTS REQUESTED

This is being submitted as a pull request rather than simply merged in order to solicit community feedback to the proposed change. If you have suggestions or concerns regarding this proposed change, please leave a comment!