### PR TITLE
Better restrict and define search order

### DIFF
--- a/searching.rst
+++ b/searching.rst
@@ -38,8 +38,9 @@ The various placeholders are as follows:
 
 :var:`name`:
   The name of the package to be located,
-  including both the proper case name,
-  and the name converted to lower case.
+  It shall be tried first in the given case,
+  and then with all characters converted
+  to lower case.
 
 :var:`name-like`:
   Any of

--- a/searching.rst
+++ b/searching.rst
@@ -51,7 +51,10 @@ The various placeholders are as follows:
   and the asterisk (``*``) is one or more
   valid filename characters, excluding the path separator.
   This is intended to allow multiple versions of a package
-  to be installed into the same :var:`prefix`.
+  to be installed into the same :var:`prefix`. All values
+  of ``*`` shall be sorted alphabetically before searching;
+  numerals first in numeric order (10 after 9),
+  then upper case letters, and finally lower case letters.
 
 :var:`libdir`:
   The platform defined directories, sans root prefix,


### PR DESCRIPTION
I am much more interested in defining these rules explicitly than in what the rules are, though I think the changes I've made are reasonable. I have a major concern that multiple CPS implementers could make different decisions on how to sort these resulting in the same project, on the same exact machine, built with two different build systems, say CMake and Meson, picking different versions of the same project as a dependency. By specifying the search order, at the very least one implementation is "wrong" and it becomes more obvious who needs to change their implementation.