### PR TITLE
searching: remove <name>-* from namelike

### DIFF
--- a/searching.rst
+++ b/searching.rst
@@ -43,8 +43,7 @@ The various placeholders are as follows:
 
 :var:`name-like`:
   Any of
-  :var:`name`\ :path:`/`\ :glob:`*`,
-  :var:`name`\ :path:`-`\ :glob:`*`, or
+  :var:`name`\ :path:`/`\ :glob:`*` or
   :var:`name`,
   where :var:`name` is as previously defined,
   and the asterisk (``*``) is one or more


### PR DESCRIPTION
This retains the potential paths to (relative to the full prefix):
  - `cps/<name>.cps`
  - `cps/<name>/<name>.cps`
  - `cps/<name>/*/<name>.cps`

While removing:
  - `cps/<name>-*/<name>.cps`

The motivation is to simplify the search procedure, and reduce the amount of I/O being done.

The reason that `<name>-*` was picked for removal is:
  1. The removed scheme does not present any options that the other schemes do not provide, while being more limited than the retained `cps/<name>/*/<name.cps>` scheme.
  2. The removed scheme requires globing directory names, while the retained schemes do not. Two schemes are static, and the third does not require globing, but instead a linear walk of the `cps/<name>/` directory is sufficient, while being more flexible.

It was agreed by those proposing the change that it would be acceptable to consider adding this path back in the future if there was a motivating reason to do so.