### PR TITLE
Update Development Process, add Contributing

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -17,7 +17,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Common Package Specification'
-copyright = u'2023, Matthew Woehlke'
+copyright = u'2024, Matthew Woehlke'
 
 release = '.'.join(map(str, [0, 10, 0]))
 version = re.match('\\d+\.\\d+', release).group(0)

--- a/development.rst
+++ b/development.rst
@@ -12,17 +12,86 @@ Development of the specification
 is intended to be an open process.
 Contributions are welcome from anyone.
 Problems or feature requests
-should be filed against the github project.
+should be filed against the GitHub project.
 
-We do not have a mailing list at this time,
-although we expect to start one
-once there is significant community involvement.
-For now, please direct comments to `the editor`_.
+Much activity and discussion takes place on GitHub,
+and we encourage use of Issues and Discussions
+as a primary communication channel.
+Some members of the community are active
+in the #ecosystem_evolution channel
+of `CppLang's Slack <https://cpplang.slack.com>`_.
+We can also be reached via our `mailing list`_.
+
+In addition, the ecosystem evolution group
+typically has at least one monthly video-conference call.
+While not strictly limited to CPS discussion,
+matters regarding the specification are sometimes discussed there.
+Additional, more CPS-focused meetings may also occur.
+See the `mailing list`_ for details.
+
+Contributing
+''''''''''''
+
+Pull requests are welcome,
+but please be aware that changes
+which have not been previously discussed
+may not be desirable, and may be rejected.
+At a minimum, if you submit a pull request
+that has not been previously discussed,
+it is likely that you will be asked to make changes
+before your proposal is accepted.
+
+When editing the documentation,
+please keep in mind that whitespace,
+and line breaks in particular,
+are not meaningful to the generated HTML.
+Accordingly, it is preferred to use these
+in a way that aims to reduce diff churn
+if and when the text is subsequently revised.
+Therefore, do not try to use all available space
+or slavishly wrap at a particular column.
+Rather, keep lines shorter
+and try to break at "natural" boundaries,
+and **always** break after a sentence.
+As a semi-hard limit, reST text
+should avoid exceeding 79 characters on a line;
+however, "properly" broken lines
+should rarely approach that limit.
+
+Commits
+^^^^^^^
+
+Commit messages shall consist of a one-line summary,
+a blank line, and a longer description.
+Summaries should ideally be 50 characters or less,
+should start with a capital letter when possible,
+should generally omit trailing punctuation,
+and should use imperative, present tense.
+Descriptions shall be wrapped at 72 characters
+except in cases where this is not possible
+(e.g. very long hyperlinks).
+
+Commits should be self-contained and complete,
+and ideally each distinct change should be a separate commit.
+"Fixup" commits should be avoided whenever possible,
+and especially should not appear in a branch
+when fixing something earlier in the branch.
+(The maintainers can and will squash pull requests if needed,
+but be aware that "dirty" history in a pull request
+makes for additional work all around.)
+
+Following a consistent style for commit messages
+helps ensure that commit messages are useful
+and makes reading the history more pleasant.
+Producing "clean" history also makes it easier
+to look back and understand change over time,
+as changes are presented in logical units
+with as little noise and clutter as possible.
 
 .. ... .. ... .. ... .. ... .. ... .. ... .. ... .. ... .. ... .. ... .. ... ..
 
 .. _github repository: https://github.com/cps-org/cps
 
-.. _the editor: mwoehlke.floss@gmail.com
+.. _mailing list: https://groups.google.com/g/cxx-ecosystem-evolution/about
 
 .. kate: hl reStructuredText


### PR DESCRIPTION
Update "Community Involvement" section of the Development Process page to more accurately reflect the current state of our communication channels. Also, add a section with advice for contributors and recommendations related to git history.