### PR TITLE
Further clarify and refine search paths

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -19,7 +19,7 @@ master_doc = 'index'
 project = u'Common Package Specification'
 copyright = u'2024, Matthew Woehlke'
 
-version_info = (0, 10, 0)
+version_info = (0, 11, 0)
 release = '.'.join(map(str, version_info))
 version = '.'.join(map(str, version_info[:2]))
 

--- a/searching.rst
+++ b/searching.rst
@@ -37,16 +37,10 @@ in the following paths:
   :applies-to:`(macOS)`
 
 - :var:`prefix`\ :path:`/`\ :var:`libdir`\
-  :path:`/`\ :var:`name-like`\ :path:`/cps/`
-
-- :var:`prefix`\ :path:`/`\ :var:`libdir`\
   :path:`/cps/`\ :var:`name-like`\ :path:`/`
 
 - :var:`prefix`\ :path:`/`\
   :var:`libdir`\ :path:`/cps/`
-
-- :var:`prefix`\ :path:`/share/`\
-  :var:`name-like`\ :path:`/cps/`
 
 - :var:`prefix`\ :path:`/share/cps/`\
   :var:`name-like`\ :path:`/`

--- a/searching.rst
+++ b/searching.rst
@@ -6,6 +6,16 @@ by searching for a file
 :var:`name`\ :path:`.cps`
 in the following paths:
 
+- :var:`environment-path`\ :path:`/`\
+  :var:`name-like`\ :path:`/cps/`
+
+- :var:`environment-path`\ :path:`/`\
+  :var:`name-like`\ :path:`/`
+
+.. raw:: never
+
+    .. This block is used to separate the above and below list items
+
 - :var:`prefix`\ :path:`/`\ :var:`name-like`\ :path:`/cps/`
   :applies-to:`(Windows)`
 
@@ -67,18 +77,28 @@ The various placeholders are as follows:
   (e.g. :path:`lib`, :path:`lib32`, :path:`lib64`,
   :path:`lib/x86_64-linux-gnu`...).
 
+:var:`environment-path`:
+  One of the set of paths
+  (separated by :path:`;` on Windows, :path:`:` otherwise)
+  in the environment variable :env:`CPS_PATH`.
+  If :env:`CPS_PATH` is empty,
+  paths starting with :var:`environment-path` are skipped.
+
 :var:`prefix`:
   One of the set of default install prefixes to be searched,
   which shall include, at minimum and in order,
   the set of paths (separated by :path:`;` on Windows, :path:`:` otherwise)
-  in the environment variable :env:`CPS_PATH`,
+  in the environment variable :env:`CPS_PREFIX_PATH`,
   :path:`/usr/local`, and :path:`/usr`.
 
-The complete list of search paths, above,
-shall be considered in the order specified above,
+All paths beginning with :var:`environment-path`
+shall be searched in the order specified above,
+for each path in :env:`CPS_PATH`,
+before the next such path is searched,
+and before any other paths are searched.
+All paths beginning with :var:`prefix`
+shall be searched in the order specified above,
 for each prefix, before the next prefix is searched.
-Package-specific prefixes shall be searched
-before package-neutral prefixes.
 
 It is recommended that tools should also provide
 a mechanism for specifying the path to a specific CPS

--- a/searching.rst
+++ b/searching.rst
@@ -6,10 +6,13 @@ by searching for a file
 :var:`name`\ :path:`.cps`
 in the following paths:
 
-- :var:`prefix`\ :path:`/cps/`
+- :var:`prefix`\ :path:`/`\ :var:`name-like`\ :path:`/cps/`
   :applies-to:`(Windows)`
 
 - :var:`prefix`\ :path:`/cps/`\ :var:`name-like`\ :path:`/`
+  :applies-to:`(Windows)`
+
+- :var:`prefix`\ :path:`/cps/`
   :applies-to:`(Windows)`
 
 - :var:`prefix`\ :path:`/`\ :var:`name`\ :path:`.framework/Versions/`\
@@ -24,10 +27,16 @@ in the following paths:
   :applies-to:`(macOS)`
 
 - :var:`prefix`\ :path:`/`\ :var:`libdir`\
+  :path:`/`\ :var:`name-like`\ :path:`/cps/`
+
+- :var:`prefix`\ :path:`/`\ :var:`libdir`\
   :path:`/cps/`\ :var:`name-like`\ :path:`/`
 
 - :var:`prefix`\ :path:`/`\
   :var:`libdir`\ :path:`/cps/`
+
+- :var:`prefix`\ :path:`/share/`\
+  :var:`name-like`\ :path:`/cps/`
 
 - :var:`prefix`\ :path:`/share/cps/`\
   :var:`name-like`\ :path:`/`
@@ -64,12 +73,6 @@ The various placeholders are as follows:
   the set of paths (separated by :path:`;` on Windows, :path:`:` otherwise)
   in the environment variable :env:`CPS_PATH`,
   :path:`/usr/local`, and :path:`/usr`.
-
-  In addition,
-  for all such package-neutral prefixes :var:`prefix-root`,
-  the package-specific prefixes
-  :var:`prefix-root`\ :path:`/`\ :var:`name-like`
-  shall also be considered.
 
 The complete list of search paths, above,
 shall be considered in the order specified above,


### PR DESCRIPTION
This PR is intended to accomplish ~~three~~ four things:

- Remove confusing wording about additional search paths in favor of explicit search paths whose effective behavior a) matches what seems to have been the intent, while b) not introducing additional paths that are unlikely to ever be used in practice.
- Further restrict search paths for the sake of consistency and performance. (This mostly eliminates the additional paths of the previous item. We may need to add them back in the future, but for now let's try the minimalist approach.)
- Use `$CPS_PREFIX_PATH` to specify additional prefixes and 'add' `$CPS_PATH` that is more similar to `$PKG_CONFIG_PATH`.
- Bump the specification version, as should have been done in #44.

Fixes #45.