### PR TITLE
Tweaks to automatic Pages generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Install Environment
         run: make setup
       - name: Build Documentation
-        run: make html
+        run: make html/fast
       - name: Archive Documentation
-        run: make archive
+        run: make archive/fast
       - name: Upload Archive
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -43,14 +43,17 @@ build.flags += $(if $(NOCOLOR),,--color)
 build.flags += $(SPHINXOPTS)
 
 .PHONY: all setup html clean.venv clean.cache clean purge archive publish
+.PHONY: setup/fast html/fast archive/fast
 
 all: html
 
-setup:
+setup: setup/fast
+setup/fast:
 	$(POETRY) check
 	$(POETRY) install $(setup.flags)
 
-html: setup
+html: setup html/fast
+html/fast:
 	$(POETRY) run sphinx-build $(build.flags) "$(SRCDIR)" "$(OUTDIR)"
 
 clean.venv:
@@ -64,7 +67,8 @@ clean:
 
 purge: clean.venv clean
 
-archive: html
+archive: html archive/fast
+archive/fast:
 	tar $(archive.flags) .
 
 publish: clean all

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ SPHINXOPTS ?=
 venv := $(notdir $(realpath $(shell $(POETRY) env info --path 2> $(--null))))
 
 archive.flags += --create --verbose
+archive.flags += --exclude=.[^/]*
 archive.flags += --file=$(ARCHIVE)
 archive.flags += --directory=$(OUTDIR)
 ifneq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build.flags += $(if $(BUILDER),-b $(BUILDER),-b html)
 build.flags += $(if $(NOCOLOR),,--color)
 build.flags += $(SPHINXOPTS)
 
-.PHONY: all setup html clean.venv clean.cache clean purge archive publish
+.PHONY: all setup html clean.venv clean.cache clean purge archive
 .PHONY: setup/fast html/fast archive/fast
 
 all: html
@@ -70,6 +70,3 @@ purge: clean.venv clean
 archive: html archive/fast
 archive/fast:
 	tar $(archive.flags) .
-
-publish: clean all
-	./publish.sh

--- a/publish.sh
+++ b/publish.sh
@@ -1,8 +1,0 @@
-#!/bin/sh -e
-
-cd _site
-git diff-index --quiet HEAD -- && exit 0
-
-git add .
-git commit -m 'Update'
-git push origin gh-pages


### PR DESCRIPTION
Tweak how GHA runs the build for slightly better performance. Don't include hidden files (i.e. build information/cache) in the Pages artifact. Remove old publication stuff.