### PR TITLE
Check Sphinx build log in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      check_result: ${{steps.check.outputs.result}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,7 +22,10 @@ jobs:
       - name: Install Environment
         run: make setup
       - name: Build Documentation
-        run: make html/fast
+        run: make html/fast LOGFILE=_build_html.log
+      - name: Parse Build Logs
+        id: check
+        run: python check-build-logs.py _build_html.log "$GITHUB_OUTPUT"
       - name: Archive Documentation
         run: make archive/fast
       - name: Upload Archive
@@ -29,6 +34,15 @@ jobs:
           if-no-files-found: error
           name: github-pages
           path: ${{github.workspace}}/cps-docs.tar
+  check:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Check Build Logs
+        env:
+          RESULT: ${{needs.build.outputs.check_result}}
+        run: |
+          exit $RESULT
   deploy:
     if: github.event.repository.default_branch == github.ref_name
     needs: build

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ endif
 setup.flags += --with=docs
 
 build.flags += $(if $(BUILDER),-b $(BUILDER),-b html)
+build.flags += $(if $(LOGFILE),-w "$(LOGFILE)")
 build.flags += $(if $(NOCOLOR),,--color)
 build.flags += $(SPHINXOPTS)
 

--- a/check-build-logs.py
+++ b/check-build-logs.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+from typing import List
+
+# -----------------------------------------------------------------------------
+def read_log(path: str) -> List[str]:
+    out = []
+
+    with open(path, 'rt') as f:
+        for line in f:
+            out.append(re.sub('\033\\[[0-9;]*m', '', line.strip()))
+
+    return out
+
+# -----------------------------------------------------------------------------
+def main(log_path: str, out_path: str):
+    re_loc = r'(?P<file>[^:]+):((?P<line>[0-9]+):)?\s*'
+    re_info = r'(?P<type>\w+):\s*(?P<message>.*)'
+    lines = read_log(log_path)
+
+    result = 0
+    for line in lines:
+        m = re.match(re_loc + re_info, line)
+        if m:
+            t = m.group('type').lower()
+            if t not in {'warning', 'error'}:
+                t = 'warning'
+
+            params = {'file': m.group('file')}
+            line = m.group('line')
+            if line:
+                params['line'] = line
+
+            p = ','.join([f'{k}={v}' for k, v in params.items()])
+            m = m.group('message')
+            print(f'::{t} {p}::{m}')
+            result = 1
+
+    with open(out_path, 'at') as f:
+        f.write(f'result={result}\n')
+
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if __name__ == '__main__':
+    main(*sys.argv[1:])


### PR DESCRIPTION
Add a script to parse a Sphinx build log and turn it into GitHub Actions formatted messages. Add ability to specify a build log output location to `Makefile`. Use these to scrape the Sphinx build log in order to report any warnings. Also, propagate the result to another job, which allows the 'build' job to pass with warnings, while the 'check' job will fail.