### PR TITLE
Make compile definitions key/value

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -17,7 +17,7 @@ master_doc = 'index'
 project = 'Common Package Specification'
 copyright = '2024, Matthew Woehlke'
 
-version_info = (0, 11, 0)
+version_info = (0, 12, 0)
 release = '.'.join(map(str, version_info))
 version = '.'.join(map(str, version_info[:2]))
 

--- a/schema.rst
+++ b/schema.rst
@@ -276,26 +276,37 @@ but not a specific component.
 :attribute:`definitions`
 ------------------------
 
-:Type: |language-string-list|
+:Type: |map| to |map| to |string|
 :Applies To: |component|, |configuration|
 :Required: No
 
-Specifies a list of compile definitions that must be defined
+Specifies a collection of compile definitions that must be defined
 when compiling code that consumes the component.
-Definitions should be in the form :string:`"FOO"` or :string:`"FOO=BAR"`.
-Additionally, a definition in the form :string:`"!FOO"`
-indicates that the specified symbol (``FOO``, in this example)
-shall be explicitly undefined (e.g. ``-UFOO`` passed to the compiler).
+Each key in the inner map(s) is the name of a compile definition,
+such that e.g. ``-Dkey=value`` is passed to the compiler.
+A value may be |null|, indicating a definition with no value
+(e.g. ``-Dkey`` is passed to the compiler).
+Note that an *empty* string indicates ``-Dkey=``,
+which may have a different effect than ``-Dkey``.
 
-A map may be used instead to give different values
-depending on the language of the consuming source file.
-In this case, the build tool shall select the list from the map
-whose (case-sensitive) key matches the (lower case) language
+The outer map is used to describe
+language-specific definitions.
+The build tool shall include
+only those definitions
+whose language matches (case-sensitive)
+that of the (lower case) language
 of the source file being compiled.
 Recognized languages shall include
 :string:`"c"`,
 :string:`"cpp"`, and
 :string:`"fortran"`.
+Additionally, the value :string:`"*"` indicates
+that the corresponding definitions apply to all languages.
+
+If a definition name is repeated
+in both :string:`"*"` and a specific language,
+the latter, when applicable to the source being compiled,
+shall have precedence.
 
 :attribute:`hints`
 ------------------


### PR DESCRIPTION
Rewrite the specification of `definitions` to separate the definition name and value. In order to keep things sane for parsers, this necessitates always specifying definitions as a language-specific map. Also add an explicit 'all languages' key (which we probably should have had all along).

In theory, this makes it easier for consumers to perform  certain operations such as querying whether a particular symbol is defined. It should also slightly simplify combining definitions from multiple components, or language-specific definitions with non-language-specific definitions (although, in practice, redefinitions on the command line are likely to be harmless).

Note that one potential complication of this approach is that it requires null values to be handled specially. This is required because we need a way to distinguish between `-Dfoo` and `-Dfoo=`, which may have different effects.

At least for now, the ability to specify explicitly undefined symbols has been dropped. Besides being rare, and potentially problematic for users, it turns out that tools may not support these either. (At least in theory, `compile_flags` can be used if necessary.)

Fixes #42.