### PR TITLE
Fix type of "definitions" attribute

### DIFF
--- a/_extensions/cps/__init__.py
+++ b/_extensions/cps/__init__.py
@@ -161,15 +161,22 @@ class AttributeDirective(Directive):
 
     # -------------------------------------------------------------------------
     def parse_type(self, typedesc):
-        if '|' in typedesc:
-            types = typedesc.split('|')
-            content = self.parse_type(types[0])
-            for t in types[1:]:
-                content += [
-                    nodes.Text(' '),
-                    nodes.inline('or', 'or', classes=['separator']),
-                    nodes.Text(' '),
-                ] + self.parse_type(t)
+        types = jsb.split_typedesc(typedesc)
+        if len(types) > 1:
+            if len(types) == 2 and 'null' in types:
+                types.remove('null')
+                content = [
+                    nodes.Text('(nullable) '),
+                ] + self.parse_type(types[0])
+
+            else:
+                content = self.parse_type(types[0])
+                for t in types[1:]:
+                    content += [
+                        nodes.Text(' '),
+                        nodes.inline('or', 'or', classes=['separator']),
+                        nodes.Text(' '),
+                    ] + self.parse_type(t)
 
             return content
 

--- a/_packages/jsb.py
+++ b/_packages/jsb.py
@@ -11,6 +11,28 @@ def decompose_typedesc(typedesc):
     return m.groups() if m else (None, typedesc)
 
 # =============================================================================
+def split_typedesc(typedesc):
+    assert typedesc.count('(') == typedesc.count(')')
+
+    types = []
+    start = 0
+    depth = 0
+    for n in range(len(typedesc)):
+        if typedesc[n] == '(':
+            depth += 1
+        elif typedesc[n] == ')':
+            assert depth > 0
+            depth -= 1
+        elif depth == 0 and typedesc[n] == '|':
+            types.append(typedesc[start:n])
+            start = n + 1
+
+    types.append(typedesc[start:])
+
+    print(f'split typedesc {typedesc!r} => {types!r}')
+    return types
+
+# =============================================================================
 class JsonSchema:
     # -------------------------------------------------------------------------
     def __init__(self, title, uri):
@@ -29,8 +51,8 @@ class JsonSchema:
             # Type already defined; nothing to do
             return
 
-        if '|' in typedesc:
-            types = typedesc.split('|')
+        types = split_typedesc(typedesc)
+        if len(types) > 1:
             for t in types:
                 self.add_type(t)
 

--- a/schema.rst
+++ b/schema.rst
@@ -248,7 +248,7 @@ Attribute names are case sensitive.
 
 .. ----------------------------------------------------------------------------
 .. cps:attribute:: definitions
-  :type: map(map(string))
+  :type: map(map(string|null))
   :context: component configuration
 
   Specifies a collection of compile definitions that must be defined


### PR DESCRIPTION
Adjust the specified type of the "definitions" attribute to reflect that null values are allowed (as specified in the prose). Improve type parsing to be more robust about how union types are split. Add support for 'nullable' types.

Currently, we don't really support prose generation for compound types where the inner value is a union type. (Schema generation doesn't have this limitation and can handle these just fine.) The 'nullable' type is a bit of a hack for this specific instance, but for now it's good enough for the types that actually exist in the schema.