### PR TITLE
search: clarify that the case of the `name` is as requested or all lower

### DIFF
--- a/searching.rst
+++ b/searching.rst
@@ -51,7 +51,7 @@ The various placeholders are as follows:
 
 :var:`name`:
   The name of the package to be located,
-  including both the proper case name,
+  including both the case as specified by the consumer,
   and the name converted to lower case.
 
 :var:`name-like`:


### PR DESCRIPTION
This means that if the requester (whether that is directly from a user or from another CPS file) specifies the name in a case that is not all lower, search for that exactly as well as the all lower.

For example, if "OpenGL" is requested, then the name should be searched as "OpenGL" and as "opengl".

I struggled a little bit with what to call the "requester", which I still don't like but can't come up with anything better.