### PR TITLE
configurations: Remove support for `:` as a separator

### DIFF
--- a/configurations.rst
+++ b/configurations.rst
@@ -78,19 +78,11 @@ the tool shall look in the same directory for any files
 which match any of the patterns
 (the asterisk (``*``) represents file globbing):
 
-  - :var:`name`\ :path:`:`\ :glob:`*`\ :path:`.cps`
-
   - :var:`name`\ :path:`-`\ :glob:`*`\ :path:`.cps`
 
   - :var:`name`\ :path:`@`\ :glob:`*`\ :path:`.cps`
 
-  - :var:`name`\ :path:`:`\ :glob:`*`\ :path:`@`\ :glob:`*`\ :path:`.cps`
-
   - :var:`name`\ :path:`-`\ :glob:`*`\ :path:`@`\ :glob:`*`\ :path:`.cps`
-
-Patterns containing colon (``:``) shall be skipped
-on platforms for which that character
-is not permitted in file names (e.g. Windows).
 
 If any such package specifications are found,
 they shall be loaded at the same time,


### PR DESCRIPTION
`:` noted to be invalid on some platforms, notably on Windows. As such, one of the two biggest platform targets for CPS will not support `:`, and tools targeting both Windows and Linux or MacOS will likely not write the files, given that they would need two separate code paths to do so. Additionally, having a character that is known to not work on some platforms complicates cross compilation with binaries. For example, if a dependency is generated on Linux, then pulled onto a Windows system to do a Windows -> Linux cross compile, A CPS file that was valid on Linux containing a `:` will not work.

Since there is already an alternative (using `-`), the most obvious solution is to simply drop `:` and only use `-`.

I've pulled this out of the discussion in #79 as an actionable item. I still have other concerns in that issue, but this seems straightforward and easy to resolve.
