### PR TITLE
Fix attribute cross-references

### DIFF
--- a/_extensions/cps/__init__.py
+++ b/_extensions/cps/__init__.py
@@ -487,7 +487,7 @@ class CpsDomain(domains.Domain):
             _, docname, refnode = c
             qualified = not short and len(attr.instances) > 1
 
-        label = refnode['names'][0]
+        label = nodes.make_id(refnode['names'][0])
 
         cont = nodes.literal('', name, classes=['attribute'])
         if qualified:


### PR DESCRIPTION
Commit 1122f58546fb added custom logic for resolving attribute references, but did so in a way that caused the resulting generated links to be non-normalized, and thus broken. Use the normalized name as the target identifier instead of the raw name.